### PR TITLE
消息中心页面高度

### DIFF
--- a/src/ui.css
+++ b/src/ui.css
@@ -491,3 +491,11 @@
 .BLOD-dl-settings .button:hover, .BLOD-dl-settings button:hover {
   background: #1890ff;
 }
+
+.container[data-v-6969394c] {
+  height: calc(100vh - 42px);
+}
+
+.container[data-v-1c9150a9] {
+  height: calc(100vh - 42px);
+}


### PR DESCRIPTION
因为旧版header更小，所以信息中心页面底部会有留白