### PR TITLE
av页合集显示

### DIFF
--- a/src/do/parameterTrim.ts
+++ b/src/do/parameterTrim.ts
@@ -37,7 +37,7 @@ class ParameterTrim {
         this.url[1] = location.href; // 暂存URL，以便比较URL变化
         if (this.url[0] != this.url[1]) {
             let href = this.triming(location.href); // 处理链接
-            window.history.replaceState(null, "", href); // 推送到地址栏
+            window.history.replaceState(window.history.state, "", href); // 推送到地址栏
             this.url[0] = location.href; // 刷新暂存
         }
     }

--- a/src/url/av/av.ts
+++ b/src/url/av/av.ts
@@ -60,6 +60,7 @@ class Av extends API.rewrite {
         ];
         this.getIniState();
         this.onload = () => { this.afterFlush() }
+        API.importModule("hookWebpackJsonp.js"); // 修复原生代码错误
     }
     async getIniState() {
         if (API.path[4].toLowerCase().startsWith('bv')) API.aid = <number>API.abv(API.path[4].split("#")[0].split("?")[0]);
@@ -123,7 +124,6 @@ class Av extends API.rewrite {
     afterFlush() {
         API.runWhile(() => document.getElementsByClassName("bili-header-m")[1], () => document.getElementsByClassName("bili-header-m")[1].remove()); // 移除上古顶栏
         window.commentAgent = { seek: (t: number) => window.player && window.player.seek(t) }; // 修复评论跳转
-        API.importModule("hookWebpackJsonp.js"); // 修复原生代码错误
         config.enlike && API.importModule("enLike.js"); // 添加点赞功能
         config.upList && this.__INITIAL_STATE__.videoData.staff && API.importModule("upList.js", { staff: this.__INITIAL_STATE__.videoData.staff }); // 合作UP主
         API.importModule("descBV.js"); // 修复简介中超链接

--- a/src/url/av/collection.ts
+++ b/src/url/av/collection.ts
@@ -1,0 +1,297 @@
+interface modules {
+    /**
+     * 合集列表
+     * 按分p方式显示, 不支持section
+     */
+    readonly "collection.js": string;
+}
+
+{
+    function calcDivWidth(text: string) {
+        let elem = document.createElement("div");
+        elem.setAttribute("style", "display: inline-block");
+        elem.innerText = text;
+        document.body.append(elem);
+        let w = elem.clientWidth;
+        document.body.removeChild(elem);
+        return w;
+    }
+
+    function calcOffsetPos(elem: HTMLElement) {
+        let result = {x: 0, y: 0};
+        for (let e = elem; e != null; e = <HTMLElement>e.offsetParent) {
+            result.x += e.offsetLeft;
+            result.y += e.offsetTop;
+        }
+        return result;
+    }
+
+    interface ContainerAttr {
+        class: string
+    }
+
+    interface ItemAttr {
+        class: string;
+        href: string;
+        text: string;
+        click: (e: Event) => any;
+    }
+
+    interface SpreadAttr {
+        top: number;
+        text?: string;
+    }
+
+    interface EpisodeItem {
+        node: HTMLAnchorElement;
+        click: (e: Event) => any;
+    }
+
+    class CollectionElement {
+        container: HTMLDivElement;
+        clearfix: HTMLElement;
+        items: EpisodeItem[] = [];
+        spread: HTMLAnchorElement = null;
+
+        constructor (onSpread: () => any) {
+            this.container = <HTMLDivElement>document.createElement("div");
+
+            this.clearfix = document.createElement("ul");
+            this.clearfix.className = "clearfix";
+            this.container.appendChild(this.clearfix);
+
+            if (onSpread) {
+                this.spread = <HTMLAnchorElement>document.createElement("a");
+                this.spread.className = "item v-part-toggle";
+                this.spread.addEventListener("click", onSpread);
+                this.clearfix.appendChild(this.spread);
+            }
+        }
+
+        setContainerAttr(attr: ContainerAttr) {
+            let staticClass = "multi-page bili-wrapper report-wrap-module report-scroll-module";
+            this.container.className = [staticClass, attr.class].join(' ').trim();
+        }
+
+        setItemAttrs(attrs: Array<ItemAttr>) {
+            // 更新分集DOM节点数量
+            while (this.items.length > attrs.length)
+                this.clearfix.removeChild(this.items.pop().node);
+
+            while (this.items.length < attrs.length)
+            {
+                let i = {node: <HTMLAnchorElement>document.createElement("a"),
+                        click: null};
+                i.node.addEventListener("mouseenter", (e) => this.showFloatTxt(e));
+                i.node.addEventListener("mouseleave", () => this.hideFloatText());
+                i.node.addEventListener("click", (e) => i.click && i.click(e));
+                this.clearfix.insertBefore(i.node, this.spread);
+                this.items.push(i);
+            }
+            // 更新DOM节点属性
+            const staticClass = "item";
+            for (let i=0; i<this.items.length; i++)
+            {
+                this.items[i].node.className = [staticClass, attrs[i].class].join(' ').trim();
+                this.items[i].node.innerText = attrs[i].text;
+                this.items[i].node.href = attrs[i].href;
+                this.items[i].click = attrs[i].click;
+            }
+        }
+
+        setSpreadAttr(attr: SpreadAttr) {
+            if (this.spread)
+            {
+                this.spread.style.top = attr.top + "px";
+                attr.text && (this.spread.innerText = attr.text);
+            }
+        }
+
+        showFloatTxt(e: Event) {
+            let item = <HTMLAnchorElement>e.target;
+            let treshold = calcDivWidth(item.innerText) + 14;
+            if (item.offsetWidth >= treshold)
+                return;
+
+            let floatTxt = document.createElement("div");
+            floatTxt.className = "p-float-txt"
+            floatTxt.innerText = item.innerText;
+            document.body.appendChild(floatTxt);
+
+            let pos = calcOffsetPos(item);
+            floatTxt.style.left = pos.x + 'px';
+            floatTxt.style.top = pos.y - 8 - floatTxt.clientHeight + 'px';
+            // transition代替animate()
+            floatTxt.style.transition = "opacity 0.4s, top 0.4s cubic-bezier(0.37, 0, 0.63, 1)";
+            floatTxt.style.top = pos.y - 3 - floatTxt.clientHeight + 'px';
+            floatTxt.style.opacity = "1";
+        }
+
+        hideFloatText() {
+            let e = document.querySelector(".p-float-txt");
+            e && document.body.removeChild(e);
+        }
+    }
+
+    class CollectionData {
+        notify: {spread: (b: boolean) => any; spreadBtnTop: (n: number) => any} = null;
+        private _viewEpisodes = [];
+        private _ep = 0;
+        private _spread = false;
+        private _spreadBtnTop = 0;
+        private _colCount = 4;
+        readonly episodes = [];
+
+        get viewEpisodes(): Array<any> {
+            return this._viewEpisodes;
+        }
+
+        get ep(): number {
+            if (this.episodes[this._ep].aid != API.aid)
+                this._ep = this.episodes.findIndex((ep) => ep.aid == API.aid)
+
+            return this._ep;
+        }
+
+        get spreadBtnTop(): number {
+            return this._spreadBtnTop;
+        }
+
+        set spreadBtnTop(n: number) {
+            if (this._spreadBtnTop != n)
+            {
+                this._spreadBtnTop = n;
+                this.notify?.spreadBtnTop(this._spreadBtnTop);
+            }
+        }
+
+        get spread(): boolean {
+            return this._spread;
+        }
+
+        get colCount(): number {
+            return this._colCount;
+        }
+
+        constructor(season: any) {
+            this.initEpisodes(season);
+            this.calcColCount();
+            this._viewEpisodes = !this.needSpread() ? this.episodes :
+                    this.calcViewEpisodesOnCollapsed(this.ep);
+        }
+
+        initEpisodes(season: any) {
+            season.sections.forEach((section) => {
+                Array.prototype.push.apply(this.episodes, section.episodes);
+            });
+        }
+
+        calcColCount() {
+            let w = calcDivWidth(this.episodes[this.ep].title);
+            this._colCount = w >= 241 ? 3 : w >= 186 ? 4 :
+                            w >= 149 ? 5 : w >= 123 ? 6 :
+                            window.innerWidth > 1440 ? 7 : 6;
+        }
+
+        calcViewEpisodesOnCollapsed(ep: number) {
+            let begin = ep == 0? 0 :
+                        ep - 1 + this._colCount <= this.episodes.length? ep - 1:
+                            this.episodes.length - this._colCount;
+
+            return this.episodes.slice(begin, begin + this._colCount);
+        }
+
+        needSpread(): boolean {
+            return this._colCount < this.episodes.length || this.spread;
+        }
+
+        toggleSpread() {
+            this._spread = !this._spread;
+            this._viewEpisodes = this._spread ? this.episodes :
+                    this.calcViewEpisodesOnCollapsed(this.ep);
+            this._spreadBtnTop = 0;
+            this.calcColCount();
+            this.notify?.spread(this._spread);
+        }
+    }
+
+    class CollectionComponent {
+        data: CollectionData;
+        elem: CollectionElement;
+
+        constructor (season: any, player: HTMLElement) {
+            this.data = new CollectionData(season);
+            this.elem = new CollectionElement(this.data.needSpread()?
+                    () => this.data.toggleSpread() : null);
+            window.addEventListener("scroll", () => this.onWindowScroll());
+            //TODO: window.popstate事件响应
+
+            this.render();
+            player.parentNode.insertBefore(this.elem.container, player);
+            this.data.notify = {
+                spread: (spread) => {
+                    this.render();
+                    // 收起时页面滚动
+                    !spread && window.scroll({top: calcOffsetPos(document.getElementById("viewbox_report")).y});
+                },
+                spreadBtnTop: (top) => {
+                    this.elem.setSpreadAttr({top: top})
+                }
+            }
+        }
+
+        render() {
+            this.elem.setContainerAttr({class: "col-" + this.data.colCount});
+            this.elem.setItemAttrs(this.data.viewEpisodes.map((p) => {
+                return {
+                    class: p.aid == API.aid? "on" : "",
+                    href: "/video/av" + p.aid,
+                    text: p.title,
+                    click: (e) => {}    //TODO: onclick
+                };
+            }, this));
+            this.elem.setSpreadAttr({
+                top: this.data.spreadBtnTop,
+                text: this.data.spread? "收起" : "展开"
+            });
+        }
+
+        onWindowScroll() {
+            if (!this.data.spread)
+                return;
+            // 展开按钮随页面滚动浮动
+            let div = this.elem.container;
+            let btn = this.elem.spread;
+            let divY = calcOffsetPos(div).y;
+            let maxTop = div.clientHeight - btn.clientHeight - 20;
+            this.data.spreadBtnTop = window.scrollY <= divY - 20? 0 :
+                Math.min(window.scrollY - divY + 20, maxTop);
+        }
+    }
+
+    class Collection {
+        component: CollectionComponent;
+
+        constructor (season: any) {
+            API.runWhile(() => document.getElementById("__bofqi"), () => {
+                try {
+                    let player = document.getElementById("__bofqi");
+                    this.component = new CollectionComponent(season, player);
+                    this.component.render();
+                } catch (e) { toast.error("collection.js", e) }
+            })
+        }
+
+        static needDisplay(videoData: any): boolean {
+            return videoData.videos <= 1 && videoData.ugc_season &&
+                videoData.is_season_display;
+        }
+
+        static run(videoData: any) {
+            this.needDisplay(videoData) && new Collection(videoData.ugc_season);
+        }
+    }
+
+    //@ts-ignore
+    Collection.run(videoData);
+}


### PR DESCRIPTION
### 详细
这个分支是没加挂载到av页面相关代码的
1. 仿照分P的方式显示合集列表；直接使用了与分P标签相同的class（目前分P视频不能加入合集所以应该没问题）
1. 合集视频替换了原有的`window.callAppointPart`（操作播放器换P时调用），供后面做播放器换P使用
1. `aid`和`cid`会保存到`window.history.state`用于浏览器回退时加载视频使用
1. `hookWebpackJsonp.js`目前在刷新后才加载，并没有实际效果；因为修改页面信息要用到，把它放到刷新前了
1. 后续要做的：
   - 设置页面开关
   - 脚本实现的页面功能换P更新，如点赞，合作up列表，分区修正
   - 换P时脚本`av.ts`中`API.mediaSession`一行报错
   - 在页面中显示合集链接？`https://space.bilibili.com/${ugc_season.mid}/channel/collectiondetail?sid=${ugc_season.id}`
   - 播放器换P
1. API和获取av页视频信息的是一样的；有合集的视频`is_season_display`值为`true`，并且会多一个`ugc_season`字段；一些字段如下
```
//uga_season
id: 128538,		//合集sid
title: "",		//合集名称
cover: "",		//合集封面
mid: 1849410874,	//up主mid
intro: "",		//合集简介
sections: []		//分章(如周刊)
stat: {}		//合集统计信息
ep_count: 1		//集数

//sections
season_id: 11		//合集id
id: 148356		//章节id
title: ""		//章节标题, 默认为"正片"
episodes: []		//单集信息

//episodes（其余字段类似View但没有up信息）
season_id: 1,		//合集id
section_id: 1,		//章节id
id: 1,			//单集id
title: ""		//分集标题(在合集中显示的名字)
``` 
### 其他
相关文章：
- 官方公告[cv14762048](https://www.bilibili.com/read/cv14762048)
- 介绍文章[cv14852441](https://www.bilibili.com/read/cv14852441)

一些测试页面：
 - [av808933177](https://www.bilibili.com/video/av808933177)
 - [av766229675](https://www.bilibili.com/video/av766229675)(自定义分集标题)
 - [av295354945](https://www.bilibili.com/video/av295354945)(分集标题截断，限制貌似是24字符)
 - [av332784259](https://www.bilibili.com/video/av332784259)(有合作视频，有不同分区)
 - [av544659074](https://www.bilibili.com/video/av544659074)(比较小的合集，测试分P标签显示用)
 - 另外需要有不同分区且包含需修正分区的页面